### PR TITLE
Add configurable swipeAssistDuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,15 @@ SwipableStack(
 );
 ```
 
+## `swipeAssistDuration`
+
+You can set the speed the use is able to swipe through Widgets with the `swipeAssistDuration`.
+
+```dart
+SwipableStack(
+  swipeAssistDuration: Duration(milliseconds: 100),
+)
+```
+
+The default is 650ms.
+

--- a/lib/src/swipable_stack.dart
+++ b/lib/src/swipable_stack.dart
@@ -238,17 +238,18 @@ typedef SwipableStackOverlayBuilder = Widget Function(
 /// A widget for stacking cards, which users can swipe horizontally and
 /// vertically with beautiful animations.
 class SwipableStack extends StatefulWidget {
-  SwipableStack({
-    required this.builder,
-    SwipableStackController? controller,
-    this.onSwipeCompleted,
-    this.onWillMoveNext,
-    this.overlayBuilder,
-    this.horizontalSwipeThreshold = _defaultHorizontalSwipeThreshold,
-    this.verticalSwipeThreshold = _defaultVerticalSwipeThreshold,
-    this.itemCount,
-    this.viewFraction = _defaultViewFraction,
-  })  : controller = controller ?? SwipableStackController(),
+  SwipableStack(
+      {required this.builder,
+      SwipableStackController? controller,
+      this.onSwipeCompleted,
+      this.onWillMoveNext,
+      this.overlayBuilder,
+      this.horizontalSwipeThreshold = _defaultHorizontalSwipeThreshold,
+      this.verticalSwipeThreshold = _defaultVerticalSwipeThreshold,
+      this.itemCount,
+      this.viewFraction = _defaultViewFraction,
+      this.swipeAssistDuration = _defaultSwipeAssistDuration})
+      : controller = controller ?? SwipableStackController(),
         assert(0 <= viewFraction && viewFraction <= 1),
         assert(0 <= horizontalSwipeThreshold && horizontalSwipeThreshold <= 1),
         assert(0 <= verticalSwipeThreshold && verticalSwipeThreshold <= 1),
@@ -284,11 +285,18 @@ class SwipableStack extends StatefulWidget {
   /// The threshold for vertical swipes.
   final double verticalSwipeThreshold;
 
+  /// How fast should the widget be swiped out of the screen when letting go?
+  /// The faster you set this, the faster you're able to swipe another Widget
+  /// of your stack.
+  final Duration swipeAssistDuration;
+
   static const double _defaultHorizontalSwipeThreshold = 0.44;
   static const double _defaultVerticalSwipeThreshold = 0.32;
   static const double _defaultViewFraction = 0.92;
 
   static const _defaultRewindDuration = Duration(milliseconds: 650);
+
+  static const _defaultSwipeAssistDuration = Duration(milliseconds: 650);
 
   @override
   _SwipableStackState createState() => _SwipableStackState();
@@ -397,7 +405,8 @@ class _SwipableStackState extends State<SwipableStack>
     final pixelPerMilliseconds = swipeDirection.isHorizontal ? 1.25 : 2.0;
 
     return Duration(
-      milliseconds: math.min(distToAssist ~/ pixelPerMilliseconds, 650),
+      milliseconds: math.min(distToAssist ~/ pixelPerMilliseconds,
+          widget.swipeAssistDuration.inMilliseconds),
     );
   }
 


### PR DESCRIPTION
_When quickly swiping over Widgets with the default duration of the Swipe Assist, that duration can be too long. This results in temporarily having a non responding stack (as it is still animating) when trying to swipe the next item._

With this change you can specify the speed for `SwipableStack` by setting its `swipeAssistDuration`.

E.g. I personally like it to have it at 100ms which allows for very quick swiping without lag :)

I've updated the code + the readme for this.