### PR TITLE
adds dragstart animation

### DIFF
--- a/lib/src/model/swipable_stack_position.dart
+++ b/lib/src/model/swipable_stack_position.dart
@@ -4,15 +4,17 @@ part of '../swipable_stack.dart';
 class _SwipableStackPosition {
   const _SwipableStackPosition({
     required this.start,
-    required this.current,
-    required this.local,
+    required this.real,
+    required this.realLocal,
+    required this.animationValue,
   });
 
   factory _SwipableStackPosition.notMoving() {
     return const _SwipableStackPosition(
       start: Offset.zero,
-      current: Offset.zero,
-      local: Offset.zero,
+      real: Offset.zero,
+      realLocal: Offset.zero,
+      animationValue: 1,
     );
   }
 
@@ -20,53 +22,66 @@ class _SwipableStackPosition {
     required SwipeDirection direction,
     required BoxConstraints areaConstraints,
   }) {
-    Offset localPosition() {
-      switch (direction) {
-        case SwipeDirection.left:
-          return Offset(
-            areaConstraints.maxWidth * 0.8,
-            areaConstraints.maxHeight * 0.4,
-          );
-        case SwipeDirection.right:
-          return Offset(
-            areaConstraints.maxWidth * 0.2,
-            areaConstraints.maxHeight * 0.4,
-          );
-        case SwipeDirection.up:
-          return Offset(
-            areaConstraints.maxWidth / 2,
-            areaConstraints.maxHeight,
-          );
-        case SwipeDirection.down:
-          return Offset(
-            areaConstraints.maxWidth / 2,
-            0,
-          );
-      }
+    Offset localPosition;
+    switch (direction) {
+      case SwipeDirection.left:
+        localPosition = Offset(
+          areaConstraints.maxWidth * 0.8,
+          areaConstraints.maxHeight * 0.4,
+        );
+        break;
+      case SwipeDirection.right:
+        localPosition = Offset(
+          areaConstraints.maxWidth * 0.2,
+          areaConstraints.maxHeight * 0.4,
+        );
+        break;
+      case SwipeDirection.up:
+        localPosition = Offset(
+          areaConstraints.maxWidth / 2,
+          areaConstraints.maxHeight,
+        );
+        break;
+      case SwipeDirection.down:
+        localPosition = Offset(
+          areaConstraints.maxWidth / 2,
+          0,
+        );
+        break;
     }
 
     return _SwipableStackPosition(
       start: Offset.zero,
-      current: Offset.zero,
-      local: localPosition(),
+      real: Offset.zero,
+      realLocal: localPosition,
+      animationValue: 1,
     );
   }
+
+  /// The value of _dragStartAnimation.
+  final double animationValue;
 
   /// The start point of swipe action.
   final Offset start;
 
   /// The current point of swipe action.
-  final Offset current;
+  Offset get current => start + (real - start) * animationValue;
+
+  /// The point which user is touching.
+  final Offset real;
+
+  /// The local point of swipe action.
+  Offset get local => realLocal * animationValue;
 
   /// The point which user is touching in the component.
-  final Offset local;
+  final Offset realLocal;
 
   @override
   bool operator ==(Object other) =>
       other is _SwipableStackPosition &&
-      start == other.start &&
-      current == other.current &&
-      local == other.local;
+          start == other.start &&
+          current == other.current &&
+          local == other.local;
 
   @override
   int get hashCode =>
@@ -76,18 +91,22 @@ class _SwipableStackPosition {
   String toString() => '$_SwipableStackPosition('
       'startPosition:$start,'
       'currentPosition:$current,'
-      'localPosition:$local'
+      'realPosition:$real,'
+      'localPosition:$local,'
+      'realLocalPosition:$realLocal'
       ')';
 
   _SwipableStackPosition copyWith({
     Offset? startPosition,
-    Offset? currentPosition,
-    Offset? localPosition,
+    Offset? realPosition,
+    Offset? realLocalPosition,
+    double? animationValue,
   }) =>
       _SwipableStackPosition(
         start: startPosition ?? start,
-        current: currentPosition ?? current,
-        local: localPosition ?? local,
+        real: realPosition ?? real,
+        realLocal: realLocalPosition ?? realLocal,
+        animationValue: animationValue ?? this.animationValue,
       );
 
   /// Difference offset from [start] to [current] .

--- a/lib/src/model/swipable_stack_position.dart
+++ b/lib/src/model/swipable_stack_position.dart
@@ -79,9 +79,9 @@ class _SwipableStackPosition {
   @override
   bool operator ==(Object other) =>
       other is _SwipableStackPosition &&
-          start == other.start &&
-          current == other.current &&
-          local == other.local;
+      start == other.start &&
+      current == other.current &&
+      local == other.local;
 
   @override
   int get hashCode =>

--- a/lib/src/model/swipe_rate_per_threshold.dart
+++ b/lib/src/model/swipe_rate_per_threshold.dart
@@ -84,7 +84,9 @@ extension _SwipableStackPositionX on _SwipableStackPosition {
     if (rateList.isEmpty) {
       return null;
     }
-    return rateList.length == 1 || rateList[0].rate > rateList[1].rate ? rateList[0] : rateList[1];
+    return rateList.length == 1 || rateList[0].rate > rateList[1].rate
+        ? rateList[0]
+        : rateList[1];
   }
 
   SwipeDirection? swipeAssistDirection({

--- a/lib/src/swipable_stack.dart
+++ b/lib/src/swipable_stack.dart
@@ -147,19 +147,19 @@ class SwipableStack extends StatefulWidget {
 class _SwipableStackState extends State<SwipableStack>
     with TickerProviderStateMixin {
   late final AnimationController _swipeCancelAnimationController =
-  AnimationController(
+      AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 500),
   );
 
   late final AnimationController _rewindAnimationController =
-  AnimationController(
+      AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 800),
   );
 
   late final AnimationController _swipeAnimationController =
-  AnimationController(
+      AnimationController(
     vsync: this,
   );
 
@@ -204,10 +204,10 @@ class _SwipableStackState extends State<SwipableStack>
         return diff < 1
             ? moveDistance
             : _remainingDistance(
-          moveDistance: moveDistance + diff,
-          maxWidth: maxWidth,
-          maxHeight: maxHeight,
-        );
+                moveDistance: moveDistance + diff,
+                maxWidth: maxWidth,
+                maxHeight: maxHeight,
+              );
       }
 
       final maxWidth = _areConstraints?.maxWidth ?? deviceSize.width;
@@ -275,14 +275,14 @@ class _SwipableStackState extends State<SwipableStack>
 
   bool get canSwipe =>
       !_swipeAssistController.animating &&
-          !_swipeAnimationController.animating &&
-          !_rewindAnimationController.animating;
+      !_swipeAnimationController.animating &&
+      !_rewindAnimationController.animating;
 
   bool get canAnimationStart =>
       !_swipeAssistController.animating &&
-          !_swipeAnimationController.animating &&
-          !_swipeCancelAnimationController.animating &&
-          !_rewindAnimationController.animating;
+      !_swipeAnimationController.animating &&
+      !_swipeCancelAnimationController.animating &&
+      !_rewindAnimationController.animating;
 
   bool get _rewinding => _rewindAnimationController.animating;
 
@@ -310,9 +310,9 @@ class _SwipableStackState extends State<SwipableStack>
       curve: widget.dragStartCurve,
       parent: _dragStartController,
     )..addListener(() {
-      widget.controller._updateSwipe(widget.controller._currentSessionState
-          ?.copyWith(animationValue: _dragStartAnimation.value));
-    });
+        widget.controller._updateSwipe(widget.controller._currentSessionState
+            ?.copyWith(animationValue: _dragStartAnimation.value));
+      });
   }
 
   @override
@@ -413,9 +413,9 @@ class _SwipableStackState extends State<SwipableStack>
               return;
             }
             final allowMoveNext = widget.onWillMoveNext?.call(
-              _currentIndex,
-              swipeAssistDirection,
-            ) ??
+                  _currentIndex,
+                  swipeAssistDirection,
+                ) ??
                 true;
             if (!allowMoveNext) {
               _cancelSwipe();
@@ -470,7 +470,7 @@ class _SwipableStackState extends State<SwipableStack>
     final session = _currentSession ?? _SwipableStackPosition.notMoving();
     final cards = List<Widget>.generate(
       stackCount,
-          (index) {
+      (index) {
         final itemIndex = _currentIndex + index;
         final child = widget.builder(
           context,
@@ -598,7 +598,7 @@ class _SwipableStackState extends State<SwipableStack>
 
     rewindAnimation.addListener(_animate);
     _rewindAnimationController.forward(from: 0).then(
-          (_) {
+      (_) {
         rewindAnimation.removeListener(_animate);
         widget.controller._initializeSessions();
       },
@@ -614,7 +614,7 @@ class _SwipableStackState extends State<SwipableStack>
       return;
     }
     final cancelAnimation =
-    _swipeCancelAnimationController.tweenCurvedAnimation(
+        _swipeCancelAnimationController.tweenCurvedAnimation(
       startPosition: currentSession.start,
       currentPosition: currentSession.current,
       curve: widget.cancelAnimationCurve,
@@ -625,7 +625,7 @@ class _SwipableStackState extends State<SwipableStack>
 
     cancelAnimation.addListener(_animate);
     _swipeCancelAnimationController.forward(from: 0).then(
-          (_) {
+      (_) {
         cancelAnimation.removeListener(_animate);
         widget.controller.cancelAction();
       },
@@ -671,7 +671,7 @@ class _SwipableStackState extends State<SwipableStack>
 
     animation.addListener(animate);
     _swipeAssistController.forward(from: 0).then(
-          (_) {
+      (_) {
         animation.removeListener(animate);
         widget.onSwipeCompleted?.call(
           _currentIndex,
@@ -697,9 +697,9 @@ class _SwipableStackState extends State<SwipableStack>
 
     if (!ignoreOnWillMoveNext) {
       final allowMoveNext = widget.onWillMoveNext?.call(
-        _currentIndex,
-        swipeDirection,
-      ) ??
+            _currentIndex,
+            swipeDirection,
+          ) ??
           true;
       if (!allowMoveNext) {
         return;
@@ -738,7 +738,7 @@ class _SwipableStackState extends State<SwipableStack>
 
     animation.addListener(animate);
     _swipeAnimationController.forward(from: 0).then(
-          (_) {
+      (_) {
         if (shouldCallCompletionCallback) {
           widget.onSwipeCompleted?.call(
             _currentIndex,

--- a/lib/src/swipable_stack.dart
+++ b/lib/src/swipable_stack.dart
@@ -328,6 +328,9 @@ class _SwipableStackState extends State<SwipableStack>
       _dragStartAnimation.curve = widget.dragStartCurve;
       _dragStartController.duration = widget.dragStartDuration;
     } else {
+      // The animation is deactivated by setting its duration to zero
+      // This way the listeners of the _dragStartAnimation are called
+      // in contrast to the approach of just not calling the controller.
       _dragStartController.duration = Duration.zero;
     }
   }
@@ -370,6 +373,9 @@ class _SwipableStackState extends State<SwipableStack>
               ),
             );
 
+            // This line must be executed in any case, so that the listeners of
+            // the animation are called. Even if the duration of the animation
+            // is zero.
             _dragStartController.forward(from: 0);
           },
           onPanUpdate: (d) {


### PR DESCRIPTION
Normally it doesn't make much difference if you choose `Dragstartbehavior.down` or `Dragstartbehavior.start` with this package. This changes if you use e.g. a list in the cards. Then the swipe gesture must first win in the gesture arena, making `Dragstartbehavior.down` more reactive. However, the animation is not so smooth in this case, which is why I added an animation for these cases. I can also add an example if desired. This animation is not executed if the default value (`Dragstartbehavior.start`) is chosen.